### PR TITLE
GitHub Personal Access Token support

### DIFF
--- a/.github/workflows/example-scan-anticrlf.yml
+++ b/.github/workflows/example-scan-anticrlf.yml
@@ -17,3 +17,7 @@ jobs:
       is-pr: true
     secrets:
       endorlabs-api-auth: ${{ secrets.ENDORLABS_API_AUTH }}
+      # to operate on a private repo, generate a github access token with `repo` rights
+      # and create an orgization or repository secret named `GITHUB_ACCESS_TOKEN`, then
+      # uncomment the line below
+      # github-access-token: ${{ secrets.GITHUB_ACCESS_TOKEN }}

--- a/.github/workflows/scan-with-endorlabs.yml
+++ b/.github/workflows/scan-with-endorlabs.yml
@@ -51,6 +51,9 @@ on:
       endorlabs-api-auth:
         description: "API auth data in the form KEY:SECRET -- if present, disables GitHub Action OIDC auth"
         required: false
+      github-access-token:
+        description: "github access token to use instead of default Actions token; may be required to clone private repos"
+        required: false
 
 jobs:
   endorlabs-auto-scan:
@@ -67,7 +70,7 @@ jobs:
       ENDOR_GITHUB_ACTION_TOKEN_ENABLE: "true"
       ENDOR_SCAN_SUMMARY_OUTPUT_TYPE: "json"
       ENDOR_SCAN_PR: ${{ inputs.is-pr }}
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.github-access-token || github.token }}
     steps:
       - id: safety-check
         name: Check safety of inputs


### PR DESCRIPTION
The Actions token can't be given enough rights to clone private repos, so we're adding an input to allow users to provide an org/repo-level secret containing a Personal Access Token or similar alternative GitHub Token with more permissions.